### PR TITLE
[fix] : 게시글 테이블에 조회수 필드 생성

### DIFF
--- a/src/main/java/com/bd/assignment1/post/Post.java
+++ b/src/main/java/com/bd/assignment1/post/Post.java
@@ -33,6 +33,8 @@ public class Post {
     @OneToMany
     private List<User> readers = new ArrayList<>();
 
+    private Long watched;
+
     @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/com/bd/assignment1/post/PostService.java
+++ b/src/main/java/com/bd/assignment1/post/PostService.java
@@ -33,6 +33,7 @@ public class PostService {
                 .title(createPostReqDto.getTitle())
                 .content(createPostReqDto.getContent())
                 .category(createPostReqDto.getCategory())
+                .watched(0L)
                 .build();
         user.addPost(post);
         return postRepository.save(post).getId();
@@ -47,13 +48,14 @@ public class PostService {
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
         if (!post.getReaders().contains(user)) {
             post.getReaders().add(user);
+            post.setWatched(post.getWatched()+1);
         }
         return ReadPostResDto.builder()
                 .title(post.getTitle())
                 .writer(post.getUser().getEmail())
                 .content(post.getContent())
                 .category(post.getCategory())
-                .count(post.getReaders().size())
+                .watched(post.getWatched())
                 .build();
     }
 

--- a/src/main/java/com/bd/assignment1/post/dto/ReadPostResDto.java
+++ b/src/main/java/com/bd/assignment1/post/dto/ReadPostResDto.java
@@ -11,5 +11,5 @@ public class ReadPostResDto {
     private String writer;
     private String content;
     private Category category;
-    private int count;
+    private Long watched;
 }

--- a/src/main/java/com/bd/assignment1/post/dto/SimplePostResDto.java
+++ b/src/main/java/com/bd/assignment1/post/dto/SimplePostResDto.java
@@ -9,13 +9,13 @@ import lombok.Data;
 public class SimplePostResDto {
     private String title;
     private String writer;
-    private int count;
+    private Long watched;
 
     public static SimplePostResDto toDto(Post post) {
         return SimplePostResDto.builder()
                 .title(post.getTitle())
                 .writer(post.getUser().getEmail())
-                .count(post.getReaders().size())
+                .watched(post.getWatched())
                 .build();
     }
 }


### PR DESCRIPTION
수정 전 : 조회수 계산을 위해 readers 테이블을 참조해야 함
->
수정 후 : 게시글 테이블에 조회수 필드를 별도로 생성